### PR TITLE
Add Makerlog to communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ by **[@mezod](https://twitter.com/mezood)** (Doing things every day with **[ever
 - **[Nugget.one](https://nugget.one/)** [$]
 
   Nugget.one focuses on helping software developers launch successful side projects. Being part of the community gives access to case studios, bi-weekly webinars and live mentoring. Run by [Justin Vincent](https://twitter.com/justinvincent). $19.99 per month.
+  
+ - **[Makerlog](https://getmakerlog.com)**
+
+  Makerlog is a free community of makers shipping products together. There's discussions + a task management tracker that allows you to get a streak (to keep you motivated shipping).
 
 ##### Other
 - **[r/Entrepreneur](https://www.reddit.com/r/Entrepreneur/)** - Not exclusive to indies/bootstrappers but still with relevant content for us.


### PR DESCRIPTION
Hi,

I've added Makerlog (getmakerlog.com) to the community list. It's been running for a while and has over 6,000 members (I run the site).