### PR TITLE
Add Invoice Chaser and Scope Creep Prevention Kit to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,14 @@ There's obviously a million posts on the topic. I'm sure this is not a good sele
 - **[free-for-dev](https://github.com/ripienaar/free-for-dev)**
 
   A list of SaaS, PaaS and IaaS offerings that have free tiers of interest to devops and infradev. Very useful for bootstrappers to keep initial costs low ;) By [R. I. Pienaar](https://github.com/ripienaar/).
+
+- **[Invoice Chaser](https://ttcd77.github.io/invoice-chaser-templates/demo.html)**
+
+  Interactive invoice tracking tool with a 5-stage email reminder system for chasing late payments. Runs entirely in-browser with zero dependencies and zero signup. Free demo; $9 one-time template pack. MIT licensed. By [Selfloom](https://github.com/ttcd77).
+
+- **[Scope Creep Prevention Kit](https://ttcd77.github.io/invoice-chaser-templates/scope-creep-kit/)**
+
+  Five professional templates (Proposal, SOW, Change Order, Revision Policy, Pushback Scripts) for freelancers to stop scope creep before it starts. Free 3-script sample; $12 one-time full kit. MIT licensed. By [Selfloom](https://github.com/ttcd77).
   
 - **[Stack-on-a-budget](https://github.com/255kb/stack-on-a-budget)**
 


### PR DESCRIPTION
Two open-source tools for indie developers and freelancers who invoice clients:

**Invoice Chaser** — Interactive invoice tracking dashboard with a 5-stage email reminder system. Track unpaid invoices, view stats, generate printable reports, and copy pre-written escalation templates. Runs entirely in-browser (localStorage, zero dependencies, no signup). Free demo; $9 one-time email template pack.
→ Live demo: https://ttcd77.github.io/invoice-chaser-templates/demo.html
→ Source: https://github.com/ttcd77/invoice-chaser-templates

**Scope Creep Prevention Kit** — 5 fill-in-the-blank professional templates (Client Proposal, SOW Agreement, Change Order Form, Revision Policy, Pushback Email Scripts). Designed for freelancers who routinely lose work to scope creep. Free 3-script sample; $12 one-time full kit.
→ Product page: https://ttcd77.github.io/invoice-chaser-templates/scope-creep-kit/
→ Source: https://github.com/ttcd77/invoice-chaser-templates

Both are MIT licensed. The free tiers are fully functional standalone. The paid tiers are optional one-time purchases (no subscriptions).

- [x] Entry follows existing format (name + link + description + license)
- [x] Project is open source (MIT)
- [x] Project has a free tier
- [x] Link goes to the tool, not a marketing page
- [x] Listed alphabetically in the Tools section