### PR TITLE
Add Ordinary Man Trying to Blogs and Case Studies sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ There's obviously a million posts on the topic. I'm sure this is not a good sele
 - **[The Bootstrapped Founder](https://thebootstrappedfounder.com/)**
 
   How to start, run, and sell a bootstrapped SaaS company without burning out — by Arvid Kahl
+
+- **[Ordinary Man Trying](https://ordinarymantrying.com)**
+
+  An ordinary Chinese person building an English blog from scratch with AI, documenting every experiment, failure, and dollar earned in public — starting from $0. 
   
 ##### Others
   
@@ -315,6 +319,10 @@ There's obviously a million posts on the topic. I'm sure this is not a good sele
 - **[Awesome Self Funded](https://github.com/awesome-self-funded/awesome-self-funded)**
 
   Awesome list of successful self-funded tech businesses with >$1M revenue
+
+- **[Building in Public: 5-Year Experiment](https://ordinarymantrying.com/building-in-public-experiment/)**
+
+  A Chinese person's public record of building an English content site from zero — tracking revenue, traffic, tools, and strategy updated weekly for 5 years.
 
 ### Events
 


### PR DESCRIPTION
Adding an English blog by a Chinese indie maker documenting building from $0 in public with AI tools.

- Blog covers SEO experiments, AI-assisted content creation, GitHub backlink strategy, and transparent revenue tracking
- The Building in Public post is updated weekly and committed to 5 years
- Transparent: currently $0 revenue, tracking everything publicly

Blog: https://ordinarymantrying.com
Case study post: https://ordinarymantrying.com/building-in-public-experiment/