### PR TITLE
Add Gathrd: Christian Event Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,5 @@ In the future, I'd like to have a list of resources for more specific topics or 
  <!-- https://www.47hats.com/2017/05/10/startup-mistake-1-anonymous-startup/ -->
  
 Help me make a proper list of specific topics!
+
+- [Gathrd: Christian Event Finder](https://getgathrd.app) - The faith-only event ticketing platform - 3% fees, Gift Aid automation for UK churches, QR check-in.


### PR DESCRIPTION
Hi — adding Gathrd: Christian Event Finder to the list.

The faith-only event ticketing platform - 3% fees, Gift Aid automation for UK churches, QR check-in.

https://getgathrd.app

Happy to adjust formatting or section placement.